### PR TITLE
Fixed typo in Cmake to avoid bugs

### DIFF
--- a/kindr_ros/CMakeLists.txt
+++ b/kindr_ros/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 include_directories(
   include
-  ${EIGERN_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}  
   ${kindr_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
metryMsgPoseTest.cpp:31:
/usr/local/include/kindr/common/common.hpp:36:10: fatal error: Eigen/Core: No such file or directory
   36 | #include <Eigen/Core>


fixed this issue and makes it easier to build kindr_ros